### PR TITLE
jsconf us link updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-The [JSConf US](http://www.jsconf.us) Site.
+The [JSConf](https://jsconf.com) Site.

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <hr/>
       <div class="clearfix">
         <div class="conf">
-          <a href="http://lastcall.jsconf.us/" rel="me"><img src="http://2015.jsconf.us/img/js-sized.png" height="200" width="200" alt="JSConf US LAST CALL"/></a>
+          <a href="https://2018.jsconf.us" rel="me"><img src="http://2015.jsconf.us/img/js-sized.png" height="200" width="200" alt="JSConf US"/></a>
           <p>JSConf US</p>
         </div>
 


### PR DESCRIPTION
### What changed?
* Updated the JSConf US link for 2018.
* Fixed the JSConf link in the readme to point to the main site.