### PR TITLE
Remove call to CSS with Bitcoin ad injector

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
 
     <link href="http://fonts.googleapis.com/css?family=ABeeZee" rel="stylesheet" type="text/css">
     <link href="http://fonts.googleapis.com/css?family=Poiret+One" rel="stylesheet" type="text/css">
-    <link href="http://dnhw55p8qm1uu.cloudfront.net/node.css" media="all" rel="stylesheet" type="text/css"/>
     <link href="css/main.css" media="all" rel="stylesheet" type="text/css"/>
 
   </head>


### PR DESCRIPTION
This asset has been replaced over on Cloudfront by a "Free Bitcoin" ad injector. Pretty sure that is not intended. 

Layout looks fine without the CSS that was there.